### PR TITLE
Run setup.py with /usr/bin/python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Distribution packaging
+/build/
+/dist/
+/si.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 from setuptools import setup
 
 setup(


### PR DESCRIPTION
The original setup.py was set to executable (+x) but could not execute because it didn't name the Python interpreter. In this way, Shell will try to execute it as a Shell script which causes confusion. Adding #!/usr/bin/python should solve this on Linux machines. (Not sure if this works on all Linux distribution or on Mac OS X.)

Another way is to simply remove the execution permission, so user knows to run it with Python.

At the same time, added a .gitignore file, ignoring distribution related files generated during installation, to make collaborators' lives easier.
